### PR TITLE
ci: trigger publish workflow on release published event

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,9 @@
 name: Publish
 
 on:
-  push:
-    tags: [v*.*.*]
+  release:
+    types:
+      - published
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
I'm not sure whether semantic-release pushes tags or only uses the API to create a release and tag in one call. If it is the latter, then this change may be needed in order to actually trigger the publish workflow whenever a new release is created.